### PR TITLE
Feature/#16 WebApp Repsoitory, Service테스트 코드 구현

### DIFF
--- a/src/main/java/swe/backend/dadlock/controller/WebAppController.java
+++ b/src/main/java/swe/backend/dadlock/controller/WebAppController.java
@@ -81,7 +81,7 @@ public class WebAppController {
             return ApiResponse.responseSuccess(StatusEnum.FORBIDDEN, null, "인증되지 않은 사용자입니다");
         }
         try {
-            webAppService.deleteWebApp(user, webAppId);
+            webAppService.deleteWebApp(user.getGoogleId(), webAppId);
             return ApiResponse.responseSuccessWithNoContent("URL 삭제 성공!");
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/src/main/java/swe/backend/dadlock/dto/webapp/WebAppRequestDTO.java
+++ b/src/main/java/swe/backend/dadlock/dto/webapp/WebAppRequestDTO.java
@@ -1,8 +1,6 @@
 package swe.backend.dadlock.dto.webapp;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import swe.backend.dadlock.entity.Subject;
 import swe.backend.dadlock.entity.User;
 import swe.backend.dadlock.entity.WebApp;
@@ -11,6 +9,8 @@ public class WebAppRequestDTO {
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
+    @Builder
+    @AllArgsConstructor
     public static class CreateDTO {
         private String appUrl;
         private int timeLimit;

--- a/src/main/java/swe/backend/dadlock/dto/webapp/WebAppResponseDTO.java
+++ b/src/main/java/swe/backend/dadlock/dto/webapp/WebAppResponseDTO.java
@@ -1,8 +1,6 @@
 package swe.backend.dadlock.dto.webapp;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import swe.backend.dadlock.entity.Subject;
 import swe.backend.dadlock.entity.WebApp;
 
@@ -10,6 +8,8 @@ public class WebAppResponseDTO {
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
+    @AllArgsConstructor
+    @Builder
     public static class CommonDTO {
         private Long id;
         private String appUrl;

--- a/src/main/java/swe/backend/dadlock/entity/User.java
+++ b/src/main/java/swe/backend/dadlock/entity/User.java
@@ -2,9 +2,7 @@ package swe.backend.dadlock.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,6 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter @Setter
 @ToString
+@NoArgsConstructor
 public class User {
 
     @Id
@@ -33,4 +32,13 @@ public class User {
     @Column(nullable = false)
     private LocalDate createdAt;
 
+    @Builder
+    public User(String googleId, String nickname, LocalDateTime recentConnect, Role role, LocalDate deleteAt, LocalDate createdAt) {
+        this.googleId = googleId;
+        this.nickname = nickname;
+        this.recentConnect = recentConnect;
+        this.role = role;
+        this.deleteAt = deleteAt;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/swe/backend/dadlock/entity/WebApp.java
+++ b/src/main/java/swe/backend/dadlock/entity/WebApp.java
@@ -36,6 +36,15 @@ public class WebApp {
         this.subject = subject;
     }
 
+    public static WebApp create(User user, String appUrl, int timeLimit, Subject subject) {
+        return WebApp.builder()
+                .user(user)
+                .appUrl(appUrl)
+                .timeLimit(timeLimit)
+                .subject(subject)
+                .build();
+    }
+
     public void updateInfo(WebAppRequestDTO.UpdateDTO dto) {
         this.appUrl = dto.getAppUrl();
         this.timeLimit = dto.getTimeLimit();

--- a/src/main/java/swe/backend/dadlock/service/WebAppService.java
+++ b/src/main/java/swe/backend/dadlock/service/WebAppService.java
@@ -24,6 +24,7 @@ public class WebAppService {
     private final UserRepository userRepository;
     private final WebAppRepository webAppRepository;
 
+    @Transactional(readOnly = true)
     public List<WebAppResponseDTO.CommonDTO> getUrlList(String userGoogleId) {
         List<WebApp> webAppListByGoogleId = webAppRepository.findWebAppListByGoogleId(userGoogleId);
         List<WebAppResponseDTO.CommonDTO> responseDTOList = webAppListByGoogleId.stream()
@@ -54,9 +55,9 @@ public class WebAppService {
         return new WebAppResponseDTO.CommonDTO(updatedWebApp);
     }
 
-    public void deleteWebApp(CustomOAuth2User user, Long webAppId) {
+    public void deleteWebApp(String userGoogleId, Long webAppId) {
         WebApp findWebApp = findWebAppById(webAppId);
-        validWebAppUrlOwner(user.getGoogleId(), findWebApp);
+        validWebAppUrlOwner(userGoogleId, findWebApp);
         webAppRepository.delete(findWebApp);
     }
 

--- a/src/test/java/swe/backend/dadlock/repository/WebAppRepositoryTest.java
+++ b/src/test/java/swe/backend/dadlock/repository/WebAppRepositoryTest.java
@@ -1,0 +1,122 @@
+package swe.backend.dadlock.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+import swe.backend.dadlock.dto.webapp.WebAppRequestDTO;
+import swe.backend.dadlock.entity.Role;
+import swe.backend.dadlock.entity.Subject;
+import swe.backend.dadlock.entity.User;
+import swe.backend.dadlock.entity.WebApp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+class WebAppRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private WebAppRepository webAppRepository;
+
+    private final String USER_GOOGLE_ID = "kim6562166086@gmail.com";
+
+    @BeforeEach
+    void beforeEach() {
+        // 유저 데이터 넣기
+        User user = createUser(USER_GOOGLE_ID, "김민형");
+        userRepository.save(user);
+    }
+
+    @DisplayName("User의 googleId에 해당하는 WebApp 엔티티들을 리스트 형태로 조회한다.")
+    @Test
+    void findWebAppListByGoogleIdTest() {
+        //given
+        String appUrl1 = "https://google.com";
+        int timeLimit1 = 20;
+        Subject subject1 = Subject.from("과학");
+
+        String appUrl2 = "https://naver.com";
+        int timeLimit2 = 15;
+        Subject subject2 = Subject.from("경제");
+
+        User findUser = findUserByGoogleId(USER_GOOGLE_ID);
+        WebApp webApp1 = WebApp.create(findUser, appUrl1, timeLimit1, subject1);
+        WebApp webApp2 = WebApp.create(findUser, appUrl2, timeLimit2, subject2);
+
+        webAppRepository.saveAll(List.of(webApp1, webApp2));
+
+        //when
+        List<WebApp> webAppList = webAppRepository.findWebAppListByGoogleId(USER_GOOGLE_ID);
+
+        //then
+        assertThat(webAppList)
+                .hasSize(2)
+                .extracting("appUrl", "timeLimit", "subject")
+                .containsExactlyInAnyOrder(
+                        tuple(appUrl1, timeLimit1, subject1),
+                        tuple(appUrl2, timeLimit2, subject2)
+                );
+    }
+
+    @DisplayName("User의 googleId와 appUrl에 해당하는 WebApp 엔티티를 조회한다")
+    @Test
+    void findWebAppByUserGoogleIdAndAppUrlTest() {
+        //given
+        String appUrl = "https://google.com";
+        int timeLimit = 20;
+        Subject subject = Subject.from("과학");
+
+        User findUser = findUserByGoogleId(USER_GOOGLE_ID);
+        WebApp webApp = WebApp.create(findUser, appUrl, timeLimit, subject);
+
+        webAppRepository.save(webApp);
+
+        //when
+        Optional<WebApp> findWebApp = webAppRepository.findWebAppByUserGoogleIdAndAppUrl(USER_GOOGLE_ID, appUrl);
+
+        //then
+        assertThat(findWebApp)
+                .isPresent()
+                .contains(webApp); // 여기서 webApp 객체가 Optional 내부에 포함되어 있는지 검증
+    }
+
+    private User findUserByGoogleId(String userGoogleId) {
+        return userRepository.findById(userGoogleId)
+                .orElseThrow(() -> new UsernameNotFoundException("유저가 존재하지 않습니다. googleId = " + userGoogleId));
+    }
+
+    private User createUser(String googleId, String nickname) {
+        return User.builder()
+                .googleId(googleId)
+                .nickname(nickname)
+                .recentConnect(LocalDateTime.now())
+                .role(Role.ROLE_USER)
+                .createdAt(LocalDate.now())
+                .build();
+    }
+
+    private static WebAppRequestDTO.CreateDTO createWebAppCreateRequestDTO(String appUrl, int timeLimit, String subject) {
+        WebAppRequestDTO.CreateDTO requestDTO = WebAppRequestDTO.CreateDTO.builder()
+                .appUrl(appUrl)
+                .timeLimit(timeLimit)
+                .subject(Subject.from(subject))
+                .build();
+        return requestDTO;
+    }
+
+}

--- a/src/test/java/swe/backend/dadlock/service/WebAppServiceTest.java
+++ b/src/test/java/swe/backend/dadlock/service/WebAppServiceTest.java
@@ -1,0 +1,208 @@
+package swe.backend.dadlock.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+import swe.backend.dadlock.dto.webapp.WebAppRequestDTO;
+import swe.backend.dadlock.dto.webapp.WebAppResponseDTO;
+import swe.backend.dadlock.entity.Role;
+import swe.backend.dadlock.entity.Subject;
+import swe.backend.dadlock.entity.User;
+import swe.backend.dadlock.entity.WebApp;
+import swe.backend.dadlock.exception.NotOwnerException;
+import swe.backend.dadlock.repository.UserRepository;
+import swe.backend.dadlock.repository.WebAppRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.DuplicateFormatFlagsException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class WebAppServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private WebAppRepository webAppRepository;
+
+    @Autowired
+    private WebAppService webAppService;
+
+    private final String USER_GOOGLE_ID = "kim6562166086@gmail.com";
+
+    @BeforeEach
+    void beforeEach() {
+        // 유저 데이터 넣기
+        User user = createUser(USER_GOOGLE_ID, "김민형");
+        userRepository.save(user);
+    }
+
+    @DisplayName("user, appUrl, timeLimit, subject를 받아 WebApp 엔티티를 생성한다.")
+    @Test
+    void createWebAppTest() {
+        //given
+        String appUrl = "https://google.com";
+        int timeLimit = 20;
+        Subject subject = Subject.from("과학");
+        WebAppRequestDTO.CreateDTO requestDTO = createWebAppCreateRequestDTO(appUrl, timeLimit, subject);
+
+        //when
+        WebAppResponseDTO.CommonDTO responseDTO = webAppService.createWebApp(USER_GOOGLE_ID, requestDTO);
+
+        //then
+        assertThat(responseDTO.getId()).isNotNull();
+        assertThat(responseDTO)
+                .extracting("appUrl", "timeLimit", "subject")
+                .contains(appUrl, timeLimit, subject);
+    }
+
+    @DisplayName("해당 유저가 이미 생성한 URL을 생성하려고하면, DuplicateFormatFlagsException이 발생한다.")
+    @Test
+    void createWebAppDuplicateTest() {
+        //given
+        String appUrl1 = "https://google.com";
+        int timeLimit1 = 20;
+        Subject subject1 = Subject.from("과학");
+
+        String appUrl2 = "https://google.com";
+        int timeLimit2 = 15;
+        Subject subject2 = Subject.from("경제");
+
+        WebAppRequestDTO.CreateDTO requestDTO1 = createWebAppCreateRequestDTO(appUrl1, timeLimit1, subject1);
+        WebAppRequestDTO.CreateDTO requestDTO2 = createWebAppCreateRequestDTO(appUrl2, timeLimit2, subject2);
+
+        webAppService.createWebApp(USER_GOOGLE_ID, requestDTO1);
+
+        //when
+        Throwable thrown = catchThrowable(() ->
+                webAppService.createWebApp(USER_GOOGLE_ID, requestDTO2)
+        );
+
+        //then
+        // 예외 메시지:  Flags = '이미 존재하는 URL입니다: https://google.com'
+        assertThat(thrown)
+                .isInstanceOf(DuplicateFormatFlagsException.class)
+                        .hasMessageContaining("이미 존재하는 URL입니다: " + requestDTO2.getAppUrl());
+
+//        assertThatThrownBy(() -> {
+//            webAppService.createWebApp(USER_GOOGLE_ID, requestDTO2);
+//        })
+//                .isInstanceOf(DuplicateFormatFlagsException.class)
+//                .hasMessageContaining("이미 존재하는 URL입니다: " + requestDTO2.getAppUrl());
+    }
+
+    @DisplayName("User의 googleId와 webApp의 id를 통해 webApp 엔티티를 삭제한다.")
+    @Test
+    void deleteWebAppTest() {
+        //given
+        String appUrl = "https://google.com";
+        int timeLimit = 20;
+        Subject subject = Subject.from("과학");
+
+        User findUser = findUserByGoogleId(USER_GOOGLE_ID);
+        WebApp webApp = WebApp.create(findUser, appUrl, timeLimit, subject);
+        webAppRepository.save(webApp);
+
+        //when
+        webAppService.deleteWebApp(findUser.getGoogleId(), webApp.getId());
+        Optional<WebApp> findWebApp = webAppRepository.findById(webApp.getId());
+
+        //then
+        assertThat(findWebApp)
+                .isEmpty();
+    }
+
+    @DisplayName("다른 유저의 webApp 엔티티를 삭제하려는 경우 NotOwnerException이 발생한다.")
+    @Test
+    void deleteWebAppOwnerTest() {
+        //given
+        String appUrl = "https://google.com";
+        int timeLimit = 20;
+        Subject subject = Subject.from("과학");
+        String otherUserGoogleId = "alsgudtkwjs@gachon.ac.kr";
+
+        User ownerUser = findUserByGoogleId(USER_GOOGLE_ID);
+        WebApp webApp = WebApp.create(ownerUser, appUrl, timeLimit, subject);
+        webAppRepository.save(webApp);
+
+        //when
+        Throwable thrown = catchThrowable(() ->
+                webAppService.deleteWebApp(otherUserGoogleId, webApp.getId())
+        );
+
+        //then
+        assertThat(thrown)
+                .isInstanceOf(NotOwnerException.class)
+                .hasMessage("다른 회원의 WebAppURL입니다. URL = " + webApp.getAppUrl());
+    }
+
+    @DisplayName("User의 googleId에 해당하는 WebApp 엔티티들을 responseDTO의 형태로 조회한다")
+    @Test
+    void getUrlListTest() {
+        //given
+        String appUrl1 = "https://google.com";
+        int timeLimit1 = 20;
+        Subject subject1 = Subject.from("과학");
+
+        String appUrl2 = "https://naver.com";
+        int timeLimit2 = 15;
+        Subject subject2 = Subject.from("경제");
+
+        User findUser = findUserByGoogleId(USER_GOOGLE_ID);
+        WebApp webApp1 = WebApp.create(findUser, appUrl1, timeLimit1, subject1);
+        WebApp webApp2 = WebApp.create(findUser, appUrl2, timeLimit2, subject2);
+
+        webAppRepository.saveAll(List.of(webApp1, webApp2));
+
+        //when
+        List<WebAppResponseDTO.CommonDTO> responseDTOList = webAppService.getUrlList(USER_GOOGLE_ID);
+
+        //then
+        assertThat(responseDTOList.get(0).getId()).isNotNull();
+        assertThat(responseDTOList.get(1).getId()).isNotNull();
+        assertThat(responseDTOList)
+                .hasSize(2)
+                .extracting("appUrl", "timeLimit", "subject")
+                .containsExactlyInAnyOrder(
+                        tuple(appUrl1, timeLimit1, subject1),
+                        tuple(appUrl2, timeLimit2, subject2)
+                );
+    }
+
+    private User findUserByGoogleId(String userGoogleId) {
+        return userRepository.findById(userGoogleId)
+                .orElseThrow(() -> new UsernameNotFoundException("유저가 존재하지 않습니다. googleId = " + userGoogleId));
+    }
+
+    private User createUser(String googleId, String nickname) {
+        return User.builder()
+                .googleId(googleId)
+                .nickname(nickname)
+                .recentConnect(LocalDateTime.now())
+                .role(Role.ROLE_USER)
+                .createdAt(LocalDate.now())
+                .build();
+    }
+
+    private static WebAppRequestDTO.CreateDTO createWebAppCreateRequestDTO(String appUrl, int timeLimit, Subject subject) {
+        WebAppRequestDTO.CreateDTO requestDTO = WebAppRequestDTO.CreateDTO.builder()
+                .appUrl(appUrl)
+                .timeLimit(timeLimit)
+                .subject(subject)
+                .build();
+        return requestDTO;
+    }
+
+}


### PR DESCRIPTION
# Feature/#16 
this closes #16 

## WebAppRepository 단위 테스트
- [ ] **beforeEach** : 각 테스트 메소드가 실행될 때마다 user 더미 데이터를 넣어주었습니다.

- [ ] **findWebAppListByGoogleIdTest** : webApp 엔티티 2개를 생성한 후 webAppRepository의 findWebAppListByGoogleId 메소드를 통해 생성된 결과값을 assertj의 hasSize(결과 값 개수 검증), extracting(결과 객체에서 속성값 추출), containsExactlyInAnyOrder(추출한 속성값이 일치하는지 검증) 메소드를 이용해서 검증하였습니다.

- [ ] **findWebAppByUserGoogleIdAndAppUrlTest** : webApp 엔티티 1개를 생성한 후 webAppRepository의 findWebAppByUserGoogleIdAndAppUrlTest 메소드를 통해 생성된 결과값을 assertj의 isPresent(Optional안에 원소가 존재하는지 검증), contains(결과 객체가 Optional 내부에 포함되어 있는지 검증) 메소드를 이용해서 검증하였습니다.


## WebAppService 단위 테스트
- [ ] **createWebAppTest** : webAppService의 createWebApp 메소드를 통해 생성된 결과값을 assertj의 extracting(결과 객체에서 속성값 추출), contains(파라미터로 넘긴 속성값이 포함되어있는지 검증) 메소드를 이용해 검증하였습니다.

- [ ] **createWebAppDuplicateTest** : createWebApp 메소드를 통해 해당 회원이 이미 생성한 URL 주소를 다시 생성하려는 경우isInstanceOf(파라미터로 넘긴 예외가 발생하는지) 메소드와 hasMessageContaining(파라미터로 넘긴 예외 메시지를 포함하는지) 메소드를 통해 DuplicateFormatFlagsException이 발생하는지, 예외 메시지는 올바른지 검증하였습니다.

- [ ] **deleteWebAppTest** : webApp 엔티티를 deleteWebApp 메소드를 통해 삭제한 후 다시 조회했을 때, Optional안이 비어있는지 isEmpty 메소드로 검증하였습니다.

- [ ] **deleteWebAppOwnerTest** : 다른 유저의 webApp 엔티티를 삭제하려는 경우 NotOwnerException이 발생하는지 isInstanceOf, hasMessage(발생한 예외 메시지가 파라미터로 넘긴 메시지와 일치하는지 검증) 메소드를 통해 검증하였습니다.

- [ ] **getUrlListTest** : 마찬가지로 WebApp 엔티티 2개를 생성하고 hasSize, extracting, containsExactlyInAnyOrder 메소드를 이용해 검증하였습니다.


## 실행화면

### WebAppServiceTest
![image](https://github.com/24SWE-Dadlock/backend/assets/113084655/50f6c8a0-c4fa-47e9-9109-051201342b79)

### WebAppRepositoryTest
![image](https://github.com/24SWE-Dadlock/backend/assets/113084655/60c4fc02-6c2f-4139-842c-98c25bccbb13)

